### PR TITLE
keep _USE_PULSEIO false for NotImplementedError

### DIFF
--- a/adafruit_hcsr04.py
+++ b/adafruit_hcsr04.py
@@ -44,7 +44,7 @@ try:
     from pulseio import PulseIn
 
     _USE_PULSEIO = True
-except ImportError:
+except (ImportError, NotImplementedError):
     pass  # This is OK, we'll try to bitbang it!
 
 __version__ = "0.0.0+auto.0"


### PR DESCRIPTION
Jetson Boards get a NotImplentedError rather than an ImportError when trying to import pulseio. By allowing NotImplementedError just like ImportError, this library works fine with the Jetson Nano.